### PR TITLE
No default unarmed conductivity

### DIFF
--- a/data/json/items/melee.json
+++ b/data/json/items/melee.json
@@ -464,7 +464,7 @@
         "name": "pair of nail knuckles",
         "name_plural": "pairs of nail knuckles",
         "description": "A pair of knuckles consisting of two small squares of wood with several nails coming through them.  Useful in nasty street fights.",
-        "material": "wood",
+        "material": ["wood", "steel"],
         "volume": 1,
         "weight": 430,
         "bashing": 4,

--- a/src/mondefense.cpp
+++ b/src/mondefense.cpp
@@ -34,7 +34,7 @@ void mdefense::zapback( monster &m, Creature *const source,
 
     // Players/NPCs can avoid the shock by using non-conductive weapons
     player const *const foe = dynamic_cast<player *>( source );
-    if( foe != nullptr && !foe->weapon.conductive() && !foe->unarmed_attack() ) {
+    if( foe != nullptr && !foe->weapon.conductive() ) {
         return;
     }
 


### PR DESCRIPTION
Allow unarmed weapons to be nonconductive, even though there are no nonconductive unarmed weapons currently in the game.